### PR TITLE
Metropolis state lazy using State (StdGen, Double)

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,31 +8,11 @@ import qualified Helpers as H
 import System.Random.MWC hiding (uniform)
 import System.Random.Stateful
 
-lazyRandomList :: RandomGen g => g -> [Int]
-lazyRandomList g =
-  x : lazyRandomList gNext
-  where
-    (x, gNext) = uniform g
-
-lazyRandomListWithState :: Int -> State StdGen [Int]
-lazyRandomListWithState = (`replicateM` randomInt)
-  where
-    randomInt :: State StdGen Int
-    randomInt = state $ uniform
-
-ioIsNotLazy :: Double -> IO [Double]
-ioIsNotLazy x = do
-  xs <- ioIsNotLazy x
-  return $ x : xs
-
 main :: IO ()
 main = do
   let n = 5
       initial = 1.0
       gen = mkStdGen 42
-      d = MhData {n = n, chain = [initial], gen = gen, logProb = H.logProb, stepsize = 0.1}
       
-      simpleRes = simpleSample d
       stateRes = sampleStateT initial gen n
-  print (chain simpleRes)
   print stateRes

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,14 +7,16 @@ import Kernels.MetropolisHastingsLazy
 import qualified Helpers as H
 import System.Random.MWC hiding (uniform)
 import System.Random.Stateful
+import Types
 
 main :: IO ()
 main = do
   let n = 5
       initial = 1.0
       gen = mkStdGen 42
+      stepsize = Stepsize 0.9
       
-      stateRes = sampleStateT initial gen n
-      stateRes' = sampleStateT' initial gen n
+      stateRes = sampleStateT H.logProb stepsize initial gen n
+      stateRes' = sampleStateT' H.logProb stepsize initial gen n
   print stateRes
   print stateRes'

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,4 +15,6 @@ main = do
       gen = mkStdGen 42
       
       stateRes = sampleStateT initial gen n
+      stateRes' = sampleStateT' initial gen n
   print stateRes
+  print stateRes'

--- a/my-mcmc.cabal
+++ b/my-mcmc.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a39c835cc331c44a903a76120e12c926c505836e69d6df854ffbe0120f99cb9b
+-- hash: e3387200826594f59cc2ee58b80110ded4c2ac2e6ccae72a965040871e5803a2
 
 name:           my-mcmc
 version:        0.1.0.0
@@ -30,6 +30,7 @@ library
       Helpers
       Kernels.MetropolisHastings
       Kernels.MetropolisHastingsLazy
+      Types
   other-modules:
       Paths_my_mcmc
   hs-source-dirs:

--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Helpers where
 
-
+import Types
 import Control.Monad.Primitive
 import Control.Monad.ST
 import System.Random.MWC (uniformR, createSystemRandom, initialize, create, Gen, GenST, Variate, uniform)
 import System.Random.MWC.Distributions
 
-logProb :: (Num a, Fractional a, Floating a) => a -> a
-logProb x = -0.5 * (x**2)
+logProb :: LogProb
+logProb = LogProb (\x -> -0.5 * (x**2))
 
 randomFloat :: IO Float
 randomFloat = uniformR (0, 1 :: Float) =<< createSystemRandom
@@ -17,14 +17,14 @@ randomFloat'' :: ST s Float
 randomFloat'' = uniformR (0, 1) =<< create -- :: ST s Float
 
 randomFloat''' :: Gen s -> ST s Float
-randomFloat''' g = uniformR (0, 1) g
+randomFloat''' = uniformR (0, 1)
 
 randomDoubleBetween :: Double -> Double -> IO Double
 randomDoubleBetween a b = uniformR (a, b) =<< createSystemRandom
 
 randomDoubleBetween' :: Double -> Double -> ST s Double
 --see https://stackoverflow.com/questions/26448677/generation-of-infinite-list-of-ints-with-mwc-random
-randomDoubleBetween' low high = 
+randomDoubleBetween' low high =
   return $ unsafeInlinePrim $ do
     gen <- createSystemRandom
     -- for debugging use:

--- a/src/Kernels/MetropolisHastings.hs
+++ b/src/Kernels/MetropolisHastings.hs
@@ -4,36 +4,35 @@ import Control.Monad.Primitive
 import Control.Monad.ST
 import Helpers (randomDoubleBetween, randomDoubleBetween')
 import System.Random.MWC
-
+import Types
 -- adapted from https://www.tweag.io/blog/2019-10-25-mcmc-intro1/
 
 -- Transition Kernel is T(x_i+1 | x_i) = proposal * acceptance_probability
 
-
-acceptanceProbability :: Double -> Double -> (Double -> Double) -> Double
-acceptanceProbability current proposal logProb =
+acceptanceProbability :: LogProb -> Double -> Double -> Double
+acceptanceProbability (LogProb logProb) current proposal  =
   min 1 (exp (logProb proposal - logProb current))
 
-propose :: PrimMonad m => Gen (PrimState m) -> Double -> Double -> m Double
-propose gen x stepsize =
-  uniformR ((x - stepsize), (x + stepsize)) gen
+propose :: PrimMonad m => Stepsize -> Gen (PrimState m) -> Double ->  m Double
+propose (Stepsize stepsize) gen current =
+  uniformR (current - stepsize, current + stepsize) gen
 
-acceptOrReject :: PrimMonad m => Gen (PrimState m ) -> Double -> (Double -> Double) -> Double -> m Double
-acceptOrReject gen current logProb proposal =
+acceptOrReject :: PrimMonad m => LogProb -> Gen (PrimState m ) -> Double -> Double -> m Double
+acceptOrReject logProb gen current proposal =
   do
     accept <- uniformR (0.0, 1.0) gen
-    if accept < acceptanceProbability current proposal logProb
+    if accept < acceptanceProbability logProb current proposal
       then return accept
       else return proposal
 
-transition :: PrimMonad m => Gen (PrimState m) -> Double -> (Double -> Double) -> Double -> m Double
-transition gen current logProb stepsize =
+transition :: PrimMonad m => LogProb -> Stepsize -> Gen (PrimState m) -> Double -> m Double
+transition logProb stepsize gen current =
   propose' >>= acceptOrReject'
-  where propose' = propose gen current stepsize
-        acceptOrReject' = acceptOrReject gen current logProb
+  where propose' = propose stepsize gen current
+        acceptOrReject' = acceptOrReject logProb gen current
 
-sample :: PrimMonad m => Gen (PrimState m) -> Double -> (Double -> Double) -> Double -> m [Double]
-sample gen current logProb stepsize = do
-  x <- return 1.0 -- transition gen current logProb stepsize
-  xs <- sample gen x logProb stepsize
+sample :: PrimMonad m => LogProb -> Stepsize -> Gen (PrimState m) -> Double -> m [Double]
+sample logProb stepsize gen current = do
+  x <- transition logProb stepsize gen current
+  xs <- sample logProb stepsize gen x
   return $ x : xs

--- a/src/Kernels/MetropolisHastingsLazy.hs
+++ b/src/Kernels/MetropolisHastingsLazy.hs
@@ -2,72 +2,66 @@ module Kernels.MetropolisHastingsLazy where
 
 import Control.Monad.State.Lazy
 import System.Random
-import Data.Coerce
-import qualified Helpers
 import Types
 
-acceptanceProbability :: Double -> Double -> Double
-acceptanceProbability current proposal =
+acceptanceProbability :: LogProb -> Double -> Double -> Double
+acceptanceProbability (LogProb logProb) current proposal =
   min 1 (exp (logProb proposal - logProb current))
-  where logProb = coerce Helpers.logProb 
 
-propose :: Double -> State StdGen Double
-propose current = state $ do
+propose :: Stepsize -> Double -> State StdGen Double
+propose (Stepsize stepsize) current = state $ do
   (proposal, newGen) <- uniformR (current - stepsize, current + stepsize)
   return (proposal, newGen)
-  where
-    stepsize = 0.9
 
-propose' :: State (StdGen, Double) Double
-propose' = do
+propose' :: Stepsize -> State (StdGen, Double) Double
+propose' (Stepsize stepsize) = do
   (gen, current) <- get
   let (proposal, newGen) = uniformR (current - stepsize, current + stepsize) gen
   put(newGen, current)
   return proposal
-  where
-    stepsize = 0.9
 
-acceptOrReject :: Double -> Double -> State StdGen Double
-acceptOrReject current proposal = state $ do
+acceptOrReject :: LogProb -> Double -> Double -> State StdGen Double
+acceptOrReject logProb current proposal = state $ do
   (rand, newGen) <- uniformR (0.0, 1.0)
-  if rand < acceptanceProbability current proposal
+  if rand < acceptanceProbability logProb current proposal
    then return (proposal, newGen)
    else return (current, newGen)
 
-acceptOrReject' :: Double -> State (StdGen, Double) Double
-acceptOrReject' proposal = do
+acceptOrReject' :: LogProb -> Double -> State (StdGen, Double) Double
+acceptOrReject' logProb proposal = do
   (gen, current) <- get
   let (rand, newGen) = uniformR (0.0, 1.0) gen
-  let nextValue = if rand < acceptanceProbability current proposal
+  let nextValue = if rand < acceptanceProbability logProb current proposal
                    then proposal
                    else current
   put (newGen, nextValue)
   return nextValue
 
-transition :: Double -> State StdGen Double
-transition current =
+transition :: LogProb -> Stepsize -> Double -> State StdGen Double
+transition logProb stepsize current =
   propose' >>= acceptOrReject'
   where
-    propose' = propose current
-    acceptOrReject' = acceptOrReject current
+    propose' = propose stepsize current
+    acceptOrReject' = acceptOrReject logProb current
 
 -- State s a
 -- State (StdGen, Double) Double 
-transition' :: State (StdGen, Double) Double
-transition' = propose' >>= acceptOrReject'
+transition' :: LogProb -> Stepsize -> State (StdGen, Double) Double
+transition' logProb stepsize = propose' stepsize >>= acceptOrReject' logProb
  
-transitionStateT :: StateT Double (State StdGen) Double
-transitionStateT = StateT $ \i -> do
+transitionStateT :: LogProb -> Stepsize -> StateT Double (State StdGen) Double
+transitionStateT logProb stepSize = StateT $ \i -> do
   gen <- get
-  let (v', gen') = runState (transition i) gen
+  let (v', gen') = runState (transition logProb stepSize i) gen
   put gen'
   return (i, v') -- State Double (Double, Double)
 
-sampleStateT :: Double -> StdGen -> Int -> ([(Double, Double)], StdGen)
-sampleStateT initial gen n =
-  let innerState = runStateT transitionStateT initial
+sampleStateT :: LogProb -> Stepsize -> Double -> StdGen -> Int -> ([(Double, Double)], StdGen)
+sampleStateT logProb stepsize initial gen n =
+  let innerState = runStateT (transitionStateT logProb stepsize) initial
   in runState (replicateM n innerState) gen
 
-sampleStateT' :: Double -> StdGen -> Int -> ([Double], (StdGen, Double))
-sampleStateT' initial gen n =
-  runState (replicateM n transition') (gen, initial)
+sampleStateT' :: LogProb -> Stepsize -> Double -> StdGen -> Int -> ([Double], (StdGen, Double))
+sampleStateT' logProb stepsize initial gen n =
+  runState (replicateM n transition'') (gen, initial)
+  where transition'' = transition' logProb stepsize

--- a/src/Kernels/MetropolisHastingsLazy.hs
+++ b/src/Kernels/MetropolisHastingsLazy.hs
@@ -2,15 +2,18 @@ module Kernels.MetropolisHastingsLazy where
 
 import Control.Monad.State.Lazy
 import System.Random
+import Data.Coerce
 import qualified Helpers
+import Types
 
 acceptanceProbability :: Double -> Double -> Double
 acceptanceProbability current proposal =
-  min 1 (exp (Helpers.logProb proposal - Helpers.logProb current))
+  min 1 (exp (logProb proposal - logProb current))
+  where logProb = coerce Helpers.logProb 
 
 propose :: Double -> State StdGen Double
-propose x = state $ do
-  (proposal, newGen) <- uniformR (x - stepsize, x + stepsize)
+propose current = state $ do
+  (proposal, newGen) <- uniformR (current - stepsize, current + stepsize)
   return (proposal, newGen)
   where
     stepsize = 0.9

--- a/src/Kernels/MetropolisHastingsLazy.hs
+++ b/src/Kernels/MetropolisHastingsLazy.hs
@@ -56,12 +56,12 @@ transitionStateT logProb stepSize = StateT $ \i -> do
   put gen'
   return (i, v') -- State Double (Double, Double)
 
-sampleStateT :: LogProb -> Stepsize -> Double -> StdGen -> Int -> ([(Double, Double)], StdGen)
-sampleStateT logProb stepsize initial gen n =
+sampleStateT :: LogProb -> Stepsize -> Int -> Double -> StdGen -> ([(Double, Double)], StdGen)
+sampleStateT logProb stepsize n initial =
   let innerState = runStateT (transitionStateT logProb stepsize) initial
-  in runState (replicateM n innerState) gen
+  in runState (replicateM n innerState)
 
-sampleStateT' :: LogProb -> Stepsize -> Double -> StdGen -> Int -> ([Double], (StdGen, Double))
-sampleStateT' logProb stepsize initial gen n =
+sampleStateT' :: LogProb -> Stepsize -> Int -> Double -> StdGen -> ([Double], (StdGen, Double))
+sampleStateT' logProb stepsize n initial gen =
   runState (replicateM n transition'') (gen, initial)
   where transition'' = transition' logProb stepsize

--- a/src/Kernels/MetropolisHastingsLazy.hs
+++ b/src/Kernels/MetropolisHastingsLazy.hs
@@ -15,12 +15,31 @@ propose x = state $ do
   where
     stepsize = 0.9
 
+propose' :: State (StdGen, Double) Double
+propose' = do
+  (gen, current) <- get
+  let (proposal, newGen) = uniformR (current - stepsize, current + stepsize) gen
+  put(newGen, current)
+  return proposal
+  where
+    stepsize = 0.9
+
 acceptOrReject :: Double -> Double -> State StdGen Double
 acceptOrReject current proposal = state $ do
   (rand, newGen) <- uniformR (0.0, 1.0)
   if rand < acceptanceProbability current proposal
    then return (proposal, newGen)
    else return (current, newGen)
+
+acceptOrReject' :: Double -> State (StdGen, Double) Double
+acceptOrReject' proposal = do
+  (gen, current) <- get
+  let (rand, newGen) = uniformR (0.0, 1.0) gen
+  let nextValue = if rand < acceptanceProbability current proposal
+                   then proposal
+                   else current
+  put (newGen, nextValue)
+  return nextValue
 
 transition :: Double -> State StdGen Double
 transition current =
@@ -29,6 +48,11 @@ transition current =
     propose' = propose current
     acceptOrReject' = acceptOrReject current
 
+-- State s a
+-- State (StdGen, Double) Double 
+transition' :: State (StdGen, Double) Double
+transition' = propose' >>= acceptOrReject'
+ 
 transitionStateT :: StateT Double (State StdGen) Double
 transitionStateT = StateT $ \i -> do
   gen <- get
@@ -36,13 +60,11 @@ transitionStateT = StateT $ \i -> do
   put gen'
   return (i, v') -- State Double (Double, Double)
 
--- State s a
--- State (StdGen, Double) Double 
-transition' :: Double -> State (StdGen, Double) Double
-transition' = undefined
-
-
 sampleStateT :: Double -> StdGen -> Int -> ([(Double, Double)], StdGen)
 sampleStateT initial gen n =
   let innerState = runStateT transitionStateT initial
   in runState (replicateM n innerState) gen
+
+sampleStateT' :: Double -> StdGen -> Int -> ([Double], (StdGen, Double))
+sampleStateT' initial gen n =
+  runState (replicateM n transition') (gen, initial)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,0 +1,3 @@
+module Types where
+newtype LogProb = LogProb (Double -> Double)
+newtype Stepsize = Stepsize Double


### PR DESCRIPTION
I have a kind of working draft without Monad Transformers.

Two things are unfinished:
 - I removed configurable options for stepsize and logprob as I needed to make the interfaces easier for me to understand. But I think this can be reintroduced easily. Also I degeneralized the signatures to Double for the same reason of not seeing the wood for the trees.
 - The new version gives a somewhat different result compared to the Monad Transformer one using the same gen. I am unsure if this is a result of the single State and the generators used in a different way now or if this is a subtle bug that I do not understand. Maybe you can have a close look if something looks implausible. I am not very sure what to expect from the mcmc as I never worked with it :)

Have a nice weekend.